### PR TITLE
Sort posts by 'config.tag_generator.order_by'

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -7,6 +7,7 @@ const defaultOption = require('./helper').defaultOption;
 module.exports = function(locals) {
   const config = this.config;
   const perPage = config.tag_generator.per_page;
+  const orderBy = config.tag_generator.order_by || '-date';
   const tags = locals.tags;
   let rootTagOption = Object.assign({}, defaultOption);
   if (config.root_tag_generator && config.root_tag_generator.root_tag_names) {
@@ -19,7 +20,8 @@ module.exports = function(locals) {
   postsMap.forEach((childTagPosts, rootTag) => {
     childTagPosts.forEach((childPosts, childTag) => {
       const path = `tags/${rootTag.slug}/${childTag.slug}/`;
-      const data = pagination(path, childPosts, {
+      const sortedChildPosts = childPosts.sort(orderBy);
+      const data = pagination(path, sortedChildPosts, {
         perPage: perPage,
         layout: ['tag', 'archive', 'index'],
         format: '/%d/',


### PR DESCRIPTION
* Sort posts by 'config.tag_generator.order_by'
  * Order by date descending by default
  * Sort order can be configurable by same way with original hexo-generator-tag (https://github.com/hexojs/hexo-generator-tag/pull/22)
